### PR TITLE
Add a readme to the CircleCI directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you have a great example of a SecretHub integration yourself or a way to impr
 ## Examples
 
 * CI/CD
-  * [Circle CI](ci/circleci/publish-docker/.circleci)
+  * [Circle CI](ci/circleci/)
   * [GitHub Actions](ci/github-actions/publish-docker/.github/workflows/main.yml)
   * Travis CI
   * GitLab CI

--- a/ci/circleci/README.md
+++ b/ci/circleci/README.md
@@ -4,8 +4,8 @@
 <br/>
 
 <p align="center">
-  <a href="https://secrethub.io/integrations/circleci/"><img alt="Learn More" src="https://secrethub.io/img/buttons/github/learn-more.png?v1" height="28" /></a>
-  <a href="https://secrethub.io/docs/guides/circleci/"><img alt="View Docs" src="https://secrethub.io/img/buttons/github/view-docs.png?v1" height="28" /></a>
+  <a href="https://secrethub.io/integrations/circleci/"><img alt="Learn More" src="https://secrethub.io/img/buttons/github/learn-more.png?v2" height="28" /></a>
+  <a href="https://secrethub.io/docs/guides/circleci/"><img alt="View Docs" src="https://secrethub.io/img/buttons/github/view-docs.png?v2" height="28" /></a>
 </p>
 <br/>
 

--- a/ci/circleci/README.md
+++ b/ci/circleci/README.md
@@ -6,8 +6,6 @@
 <p align="center">
   <a href="https://secrethub.io/integrations/circleci/"><img alt="Learn More" src="https://secrethub.io/img/buttons/github/learn-more.png?v1" height="28" /></a>
   <a href="https://secrethub.io/docs/guides/circleci/"><img alt="View Docs" src="https://secrethub.io/img/buttons/github/view-docs.png?v1" height="28" /></a>
-  <a href="https://github.com/secrethub/secrethub-circleci-orb"><img alt="View Source Code" src="https://secrethub.io/img/buttons/github/view-source.png?v1" height="28" /></a>
-  <a href="https://circleci.com/orbs/registry/orb/secrethub/cli"><img alt="View Orb" src="https://secrethub.io/img/buttons/github/view-orb.png?v1" height="28" /></a>
 </p>
 <br/>
 

--- a/ci/circleci/README.md
+++ b/ci/circleci/README.md
@@ -14,3 +14,5 @@
 <h1>
   CircleCI Examples
 </h1>
+
+- [Publish Docker](./publish-docker/.circleci/config.yml)

--- a/ci/circleci/README.md
+++ b/ci/circleci/README.md
@@ -1,0 +1,16 @@
+<p align="center">
+  <img src="https://secrethub.io/img/integrations/circleci/github-banner.png?v1" alt="CircleCI + SecretHub" width="390">
+</p>
+<br/>
+
+<p align="center">
+  <a href="https://secrethub.io/integrations/circleci/"><img alt="Learn More" src="https://secrethub.io/img/buttons/github/learn-more.png?v1" height="28" /></a>
+  <a href="https://secrethub.io/docs/guides/circleci/"><img alt="View Docs" src="https://secrethub.io/img/buttons/github/view-docs.png?v1" height="28" /></a>
+  <a href="https://github.com/secrethub/secrethub-circleci-orb"><img alt="View Source Code" src="https://secrethub.io/img/buttons/github/view-source.png?v1" height="28" /></a>
+  <a href="https://circleci.com/orbs/registry/orb/secrethub/cli"><img alt="View Orb" src="https://secrethub.io/img/buttons/github/view-orb.png?v1" height="28" /></a>
+</p>
+<br/>
+
+<h1>
+  CircleCI Examples
+</h1>


### PR DESCRIPTION
The readme references other relevant sources, such as the
docs, the integration page on the website, the orb page and the
orb source code.

The readme can be expanded by adding some guidelines, such as
when to use the `secrethub/exec` orb and when to override the
shell instead.