### PR TITLE
Add link to rails example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ If you have a great example of a SecretHub integration yourself or a way to impr
   * [Django](application/django)
   * [Node.js](application/nodejs)
   * [Ruby](application/ruby)
-  * Rails
+  * [Rails](application/rails)
   * [Spring-boot](application/spring-boot)
   * [ASP.NET](application/aspnet)


### PR DESCRIPTION
Adds a missing link to the README.