### PR TITLE
Prettify application examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you have a great example of a SecretHub integration yourself or a way to impr
   * [Node.js](application/nodejs)
   * [Ruby](application/ruby)
   * [Rails](application/rails)
-  * [Spring-boot](application/spring-boot)
+  * [Spring Boot](application/spring-boot)
   * [ASP.NET](application/aspnet)
 * DevOps tools
   * Terraform

--- a/application/aspnet/Dockerfile
+++ b/application/aspnet/Dockerfile
@@ -24,6 +24,6 @@ RUN apk add --repository https://alpine.secrethub.io/alpine/edge/main --allow-un
 EXPOSE 80
 
 # Add the SecretHub entrypoint
-ENTRYPOINT ["secrethub","run","--"]
+ENTRYPOINT ["secrethub", "run", "--"]
 
 CMD ["./example"]

--- a/application/aspnet/README.md
+++ b/application/aspnet/README.md
@@ -1,16 +1,16 @@
-# ASP.NET application in Docker
-This ASP.NET example checks if the environment variables DEMO_USERNAME and DEMO_PASSWORD are set. If they are, the application responds (at localhost:8080) to the requests with a status code 200 and a welcome message. If not, the application responds with status code 500.
+<p align="center">
+  <img src="https://secrethub.io/img/integrations/aspnet/github-banner.png?v1" alt="ASP.NET + SecretHub" height="230">
+</p>
+<br/>
+
+This ASP.NET example checks if the environment variables `DEMO_USERNAME` and `DEMO_PASSWORD` have been set. If that's the case, you'll receive a `200` on http://localhost:8080 and if it's not, you'll get a `500`.
 
 ## Prerequisites
 1. [Docker](https://docs.docker.com/install/) installed and running
-2. [SecretHub](https://secrethub.io/docs/start/getting-started/#install) installed
+1. [SecretHub](https://secrethub.io/docs/start/getting-started/#install) installed
+1. A SecretHub repo that contains a `username` and `password` secret. To create it, run `secrethub demo init`.
 
 ## Running the example
-
-Init the SecretHub demo repo with example values
-```
-secrethub demo init
-```
 
 Set the SecretHub username in an environment variable
 ```

--- a/application/django/Dockerfile
+++ b/application/django/Dockerfile
@@ -24,7 +24,7 @@ COPY views.py views.py
 EXPOSE 8000
 
 # Add the SecretHub entrypoint
-ENTRYPOINT ["secrethub","run","--"]
+ENTRYPOINT ["secrethub", "run", "--"]
 
 # Start the main process
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/application/django/README.md
+++ b/application/django/README.md
@@ -1,16 +1,21 @@
-# Django application in Docker
-This Django example checks if the environment variables `DEMO_USERNAME` and `DEMO_PASSWORD` are set. If they are, the application responds (at localhost:8080) to the requests with a status code 200 and a welcome message. If not, the application responds with status code 500.
+<p align="center">
+  <img src="https://secrethub.io/img/integrations/django/github-banner.png?v1" alt="Django + SecretHub" height="230">
+</p>
+<br/>
+
+<p align="center">
+  <a href="https://secrethub.io/docs/guides/django/"><img alt="View Docs" src="https://secrethub.io/img/buttons/github/view-docs.png?v2" height="28" /></a>
+</p>
+<br/>
+
+This Django example checks if the environment variables `DEMO_USERNAME` and `DEMO_PASSWORD` have been set. If that's the case, you'll receive a `200` on http://localhost:8080 and if it's not, you'll get a `500`.
 
 ## Prerequisites
 1. [Docker](https://docs.docker.com/install/) installed and running
-2. [SecretHub](https://secrethub.io/docs/start/getting-started/#install) installed
+1. [SecretHub](https://secrethub.io/docs/start/getting-started/#install) installed
+1. A SecretHub repo that contains a `username` and `password` secret. To create it, run `secrethub demo init`.
 
 ## Running the example
-
-Init the SecretHub demo repo with example values
-```
-secrethub demo init
-```
 
 Set the SecretHub username in an environment variable
 ```

--- a/application/flask/Dockerfile
+++ b/application/flask/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --repository https://alpine.secrethub.io/alpine/edge/main --allow-un
 EXPOSE 5000
 
 # # Add the SecretHub entrypoint
-ENTRYPOINT ["secrethub","run","--"]
+ENTRYPOINT ["secrethub", "run", "--"]
 
 # Start the main process
-CMD ["python","app.py"]
+CMD ["python", "app.py"]

--- a/application/flask/README.md
+++ b/application/flask/README.md
@@ -1,16 +1,16 @@
-# flask application in Docker
-This flask example checks if the environment variables DEMO_USERNAME and DEMO_PASSWORD are set. If they are, the application responds (at localhost:8080) to the requests with a status code 200 and a welcome message. If not, the application responds with status code 500.
+<p align="center">
+  <img src="https://secrethub.io/img/integrations/flask/github-banner.png?v1" alt="Flask + SecretHub" height="230">
+</p>
+<br/>
+
+This Flask example checks if the environment variables `DEMO_USERNAME` and `DEMO_PASSWORD` have been set. If that's the case, you'll receive a `200` on http://localhost:8080 and if it's not, you'll get a `500`.
 
 ## Prerequisites
 1. [Docker](https://docs.docker.com/install/) installed and running
-2. [SecretHub](https://secrethub.io/docs/start/getting-started/#install) installed
+1. [SecretHub](https://secrethub.io/docs/start/getting-started/#install) installed
+1. A SecretHub repo that contains a `username` and `password` secret. To create it, run `secrethub demo init`.
 
 ## Running the example
-
-Init the SecretHub demo repo with example values
-```
-secrethub demo init
-```
 
 Set the SecretHub username in an environment variable
 ```

--- a/application/nodejs/Dockerfile
+++ b/application/nodejs/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --repository https://alpine.secrethub.io/alpine/edge/main --allow-un
 EXPOSE 8080
 
 # Add the SecretHub entrypoint
-ENTRYPOINT ["secrethub","run","--"]
+ENTRYPOINT ["secrethub", "run", "--"]
 
 # Start the main process
-CMD ["npm","start"]
+CMD ["npm", "start"]

--- a/application/nodejs/README.md
+++ b/application/nodejs/README.md
@@ -1,16 +1,21 @@
-# Node.js application in Docker
-This Node.js example checks if the environment variables `DEMO_USERNAME` and `DEMO_PASSWORD` are set. If they are, the application responds (at localhost:8080) to the requests with a status code 200 and a welcome message. If not, the application responds with status code 500.
+<p align="center">
+  <img src="https://secrethub.io/img/integrations/nodejs/github-banner.png?v1" alt="Node.js + SecretHub" height="230">
+</p>
+<br/>
+
+<p align="center">
+  <a href="https://secrethub.io/docs/guides/nodejs/"><img alt="View Docs" src="https://secrethub.io/img/buttons/github/view-docs.png?v2" height="28" /></a>
+</p>
+<br/>
+
+This Node.js example checks if the environment variables `DEMO_USERNAME` and `DEMO_PASSWORD` have been set. If that's the case, you'll receive a `200` on http://localhost:8080 and if it's not, you'll get a `500`.
 
 ## Prerequisites
 1. [Docker](https://docs.docker.com/install/) installed and running
-2. [SecretHub](https://secrethub.io/docs/start/getting-started/#install) installed
+1. [SecretHub](https://secrethub.io/docs/start/getting-started/#install) installed
+1. A SecretHub repo that contains a `username` and `password` secret. To create it, run `secrethub demo init`.
 
 ## Running the example
-
-Init the SecretHub demo repo with example values
-```
-secrethub demo init
-```
 
 Set the SecretHub username in an environment variable
 ```

--- a/application/rails/Dockerfile
+++ b/application/rails/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /myapp/secrethub_demo/
 EXPOSE 3000
 
 # Add the secrethub entrypoint
-ENTRYPOINT ["secrethub","run","--"]
+ENTRYPOINT ["secrethub", "run", "--"]
 
 # Start the main process
-CMD ["rails","server","-b","0.0.0.0"]
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/application/rails/README.md
+++ b/application/rails/README.md
@@ -1,16 +1,16 @@
-# Rails application in Docker
-This rails example checks if the environment variables DEMO_USERNAME and DEMO_PASSWORD are set. If they are, the application responds (at localhost:8080) to the requests with a status code 200 and a welcome message. If not, the application responds with status code 500.
+<p align="center">
+  <img src="https://secrethub.io/img/integrations/rails/github-banner.png?v1" alt="Rails + SecretHub" height="230">
+</p>
+<br/>
+
+This Ruby on Rails example checks if the environment variables `DEMO_USERNAME` and `DEMO_PASSWORD` have been set. If that's the case, you'll receive a `200` on http://localhost:8080 and if it's not, you'll get a `500`.
 
 ## Prerequisites
 1. [Docker](https://docs.docker.com/install/) installed and running
-2. [SecretHub](https://secrethub.io/docs/start/getting-started/#install) installed
+1. [SecretHub](https://secrethub.io/docs/start/getting-started/#install) installed
+1. A SecretHub repo that contains a `username` and `password` secret. To create it, run `secrethub demo init`.
 
 ## Running the example
-
-Init the SecretHub demo repo with example values
-```
-secrethub demo init
-```
 
 Set the SecretHub username in an environment variable
 ```

--- a/application/ruby/Dockerfile
+++ b/application/ruby/Dockerfile
@@ -14,7 +14,7 @@ RUN bundle install
 EXPOSE 4567
 
 # Add the secrethub entrypoint
-ENTRYPOINT ["secrethub","run","--"]
+ENTRYPOINT ["secrethub", "run", "--"]
 
 # Start the main process
 CMD ["ruby", "myapp.rb"]

--- a/application/ruby/README.md
+++ b/application/ruby/README.md
@@ -1,16 +1,13 @@
 # Ruby application in Docker
-This ruby example checks if the environment variables DEMO_USERNAME and DEMO_PASSWORD are set. If they are, the application responds (at localhost:8080) to the requests with a status code 200 and a welcome message. If not, the application responds with status code 500.
+
+This Ruby example checks if the environment variables `DEMO_USERNAME` and `DEMO_PASSWORD` have been set. If that's the case, you'll receive a `200` on http://localhost:8080 and if it's not, you'll get a `500`.
 
 ## Prerequisites
 1. [Docker](https://docs.docker.com/install/) installed and running
-2. [SecretHub](https://secrethub.io/docs/start/getting-started/#install) installed
+1. [SecretHub](https://secrethub.io/docs/start/getting-started/#install) installed
+1. A SecretHub repo that contains a `username` and `password` secret. To create it, run `secrethub demo init`.
 
 ## Running the example
-
-Init the SecretHub demo repo with example values
-```
-secrethub demo init
-```
 
 Set the SecretHub username in an environment variable
 ```

--- a/application/spring-boot/Dockerfile
+++ b/application/spring-boot/Dockerfile
@@ -22,7 +22,7 @@ RUN apk add --repository https://alpine.secrethub.io/alpine/edge/main --allow-un
 EXPOSE 8080
 
 # Add the SecretHub entrypoint
-ENTRYPOINT ["secrethub","run","--"]
+ENTRYPOINT ["secrethub", "run", "--"]
 
 # Start the main process
-CMD ["java","-jar","/example.jar"]
+CMD ["java", "-jar", "/example.jar"]

--- a/application/spring-boot/README.md
+++ b/application/spring-boot/README.md
@@ -1,16 +1,16 @@
-# Spring-boot application in Docker
-This spring-boot example checks if the environment variables DEMO_USERNAME and DEMO_PASSWORD are set. If they are, the application responds (at localhost:8080) to the requests with a status code 200 and a welcome message. If not, the application responds with status code 500.
+<p align="center">
+  <img src="https://secrethub.io/img/integrations/spring-boot/github-banner.png?v1" alt="Spring Boot + SecretHub" height="230">
+</p>
+<br/>
+
+This Spring Boot example checks if the environment variables `DEMO_USERNAME` and `DEMO_PASSWORD` have been set. If that's the case, you'll receive a `200` on http://localhost:8080 and if it's not, you'll get a `500`.
 
 ## Prerequisites
 1. [Docker](https://docs.docker.com/install/) installed and running
-2. [SecretHub](https://secrethub.io/docs/start/getting-started/#install) installed
+1. [SecretHub](https://secrethub.io/docs/start/getting-started/#install) installed
+1. A SecretHub repo that contains a `username` and `password` secret. To create it, run `secrethub demo init`.
 
 ## Running the example
-
-Init the SecretHub demo repo with example values
-```
-secrethub demo init
-```
 
 Set the SecretHub username in an environment variable
 ```


### PR DESCRIPTION
With README banners and buttons wherever applicable. Also made `demo init` a prerequisite, rather than a step to declutter the important stuff.